### PR TITLE
feat(poker-state-machine): FIX the bug and add winner handling

### DIFF
--- a/packages/poker-state-machine/src/schemas.ts
+++ b/packages/poker-state-machine/src/schemas.ts
@@ -62,6 +62,7 @@ export const PokerStateSchema = Schema.Struct({
     bet: Schema.Number,
     // TODO: actually consider going back to dealerIndex instead xD
     dealerId: Schema.String,
+    winner: Schema.Option(Schema.String),
 })
 export type PokerState = typeof PokerStateSchema.Type
 

--- a/packages/poker-state-machine/src/state_machine.ts
+++ b/packages/poker-state-machine/src/state_machine.ts
@@ -1,4 +1,5 @@
 import { type PlayerState, type PokerState } from "./schemas";
+import { Option } from "effect";
 
 export const POKER_ROOM_DEFAULT_STATE: PokerState = {
   status: "WAITING",
@@ -10,6 +11,7 @@ export const POKER_ROOM_DEFAULT_STATE: PokerState = {
   // FIXME: both of these are bad default values, refactor later
   dealerId: '',
   currentPlayerIndex: -1,
+  winner: Option.none(),
 };
 
 export const PLAYER_DEFAULT_STATE: Omit<PlayerState, "id"> = {


### PR DESCRIPTION
- Refactor pot calculation logic for consistency and FIX the bug
- Introduce 'winner' field in PokerStateSchema to track the round winner
- Initialize winner in POKER_ROOM_DEFAULT_STATE using Option.none()
- Update showdown function to determine and return the winner after round completion

#82 