### PR TITLE
refactor: Poker Implement All-in and Improve Game Logic #113

### DIFF
--- a/packages/front/src/app/globals.css
+++ b/packages/front/src/app/globals.css
@@ -136,13 +136,13 @@ body {
 /* Neon Poker Table Styles */
 .poker-table-container {
   position: relative;
-  width: 80vw;
-  height: 80vh;
+  width: 60vw;
+  height: 60vh;
   max-width: 1000px;
   max-height: 600px;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: start;
 }
 
 .table-surface {

--- a/packages/front/src/app/page.tsx
+++ b/packages/front/src/app/page.tsx
@@ -9,6 +9,7 @@ import { CONTRACT_ID } from "@/utils/constants";
 import { BettingPanel } from "@/components/BettingPanel";
 import { usePlayerBetting } from "@/hooks/usePlayerBetting";
 import { Chat } from "@/components/Chat";
+import { MoveHistoryPanel } from "@/components/MoveHistoryPanel";
 
 function PageLayout({ children }: { children: ReactNode }) {
   return (
@@ -51,9 +52,8 @@ export default function Home() {
         const state = await fetch('/api/current-state');
         const data = await state.json();
         
-        
         // Only update the state if the data is different
-        if (JSON.stringify(data) !== JSON.stringify(gameState)) {
+        if (JSON.stringify(data) !== JSON.stringify(gameState) && !data?.error) {
           setGameState(data);
           console.log("🔍 Game state:", data);
         }
@@ -89,7 +89,9 @@ export default function Home() {
   if (!gameState) {
     return (
       <PageLayout>
-        <div className="text-neon-yellow text-2xl">No game state available</div>
+        <div className="text-neon-yellow text-2xl flex justify-center items-center" style={{ marginTop: '200px' }}>
+          Waiting for game...
+        </div>
       </PageLayout>
     );
   }
@@ -98,15 +100,15 @@ export default function Home() {
     <PageLayout>
       <div className="h-full flex flex-col">
         <div className="flex-grow flex flex-row">
-          <div className="flex-grow">
-            <PokerTable 
-              gameState={gameState} 
-              playerBets={playerBets}
-            />
+          <div className="w-[300px] p-4">
+            <MoveHistoryPanel gameState={gameState} />
           </div>
-          <div className="w-80 p-4">
+          <div className="flex-grow">
+            <PokerTable gameState={gameState} playerBets={playerBets} />
+          </div>
+          <div className="w-[300px] p-4">
             <BettingPanel
-              players={[...gameState.players]}
+              players={gameState?.players?.length > 0 ? [...gameState.players] : []}
               playerBets={playerBets}
               onPlaceBet={placeBet}
               userBalance={userBalance}
@@ -114,12 +116,16 @@ export default function Home() {
             />
             {bettingError && (
               <div className="mt-4 p-2 border border-theme-alert rounded-border-radius-element bg-surface-secondary">
-                <p className="text-theme-alert text-shadow-red text-sm">{bettingError}</p>
+                <p className="text-theme-alert text-shadow-red text-sm">
+                  {bettingError}
+                </p>
               </div>
             )}
             {bettingLoading && (
               <div className="mt-4 text-center">
-                <p className="text-theme-secondary text-shadow-cyan text-sm">Loading...</p>
+                <p className="text-theme-secondary text-shadow-cyan text-sm">
+                  Loading...
+                </p>
               </div>
             )}
           </div>

--- a/packages/front/src/components/Chat.tsx
+++ b/packages/front/src/components/Chat.tsx
@@ -19,7 +19,7 @@ export const Chat: React.FC<ChatProps> = ({ gameState }) => {
 
   useEffect(() => {
     const roleplay = gameState?.lastMove?.move?.decisionContext?.roleplay;
-    const player = gameState?.players.find(
+    const player = gameState?.players?.find(
       (p) => p.id === gameState?.lastMove?.playerId
     );
     if (roleplay && player) {

--- a/packages/front/src/components/MoveHistoryPanel.tsx
+++ b/packages/front/src/components/MoveHistoryPanel.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { PokerState } from '../types/poker';
+
+interface MoveHistoryPanelProps {
+  gameState: PokerState;
+}
+
+export const MoveHistoryPanel: React.FC<MoveHistoryPanelProps> = ({ gameState }) => {
+    const [moveHistory, setMoveHistory] = useState<PokerState["lastMove"][]>(
+      []
+    );
+
+  useEffect(() => {
+    // Add new move to history if it exists and is different from the last one
+    if (
+      gameState.lastMove &&
+      (!moveHistory.length ||
+        JSON.stringify(gameState.lastMove) !==
+          JSON.stringify(moveHistory[moveHistory.length - 1]))
+    ) {
+      setMoveHistory((prev) => [...prev, gameState.lastMove]);
+    }
+  }, [gameState.lastMove, moveHistory]);
+
+  const getMoveDescription = (move: NonNullable<PokerState["lastMove"]>) => {
+    const { playerId, move: playerMove } = move;
+    console.log("🔍 Move:", move);
+    const playerName = gameState.players.find(p => p.id === playerId)?.playerName ?? playerId;
+
+    switch (playerMove.type) {
+      case "fold":
+        return `Round ${gameState.round.roundNumber} - Street ${gameState.round.phase} - ${playerName} - folded`;
+      case "call":
+        return `Round ${gameState.round.roundNumber} - Street ${gameState.round.phase} - ${playerName} - called`;
+      case "all_in":
+        return `Round ${gameState.round.roundNumber} - Street ${gameState.round.phase} - ${playerName} - went all in`;
+      case "raise":
+        return `Round ${gameState.round.roundNumber} - Street ${gameState.round.phase} - ${playerName} - raised to ${playerMove.amount}`;
+      default:
+        return "Unknown move";
+    }
+  };
+
+  return (
+    <div className="bg-surface-primary rounded-border-radius-element p-4 border border-theme-primary rounded-border-radius-element">
+      <h3 className="text-theme-primary text-shadow-cyan mb-4">Move History</h3>
+      <div className="max-h-96 overflow-y-auto">
+        {moveHistory?.length === 0 ? (
+          <p className="text-theme-secondary text-shadow-cyan text-sm">
+            No moves yet
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {moveHistory.map(
+              (move, index) =>
+                move && (
+                  <li
+                    key={index}
+                    className="text-theme-primary text-shadow-cyan text-sm p-2 bg-surface-secondary rounded-border-radius-element"
+                  >
+                    {getMoveDescription(move)}
+                    {/* {move.move.decisionContext?.explanation && (
+                      <p className="text-xs text-theme-secondary mt-1">
+                        {move.move.decisionContext.explanation}
+                      </p>
+                    )} */}
+                  </li>
+                )
+            )}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}; 

--- a/packages/front/src/components/PokerTable.tsx
+++ b/packages/front/src/components/PokerTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card } from './Card';
 import { Player } from './Player';
 import { PokerState, formatChips, getPhaseLabel } from '../types/poker';
@@ -23,10 +23,18 @@ export const PokerTable: React.FC<PokerTableProps> = ({
   gameState,
   playerBets
 }) => {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (gameState?.players?.length > 1) {
+      setReady(true);
+    }
+  }, [gameState]);
+  console.log("🔍 Game state:", gameState);
   return (
     <div className="h-full bg-black flex flex-row">
       {/* Main poker table */}
-      <div className="flex-grow flex justify-center items-center">
+      <div className="flex-grow flex justify-center items-start">
         <div className="poker-table-container">
           <div className="table-surface">
             {/* Players */}
@@ -54,7 +62,7 @@ export const PokerTable: React.FC<PokerTableProps> = ({
             <div className="center-area">
               {/* Game status */}
               <div className="game-status">
-                {gameState.tableStatus === "WAITING" && "Waiting for players..."}
+                {gameState.tableStatus === "PLAYING" && !ready && "Waiting for players..."}
                 {gameState.tableStatus === "ROUND_OVER" && gameState.winner && `Winner: ${gameState.winner}`}
                 {gameState.tableStatus === "GAME_OVER" && gameState.winner && `Game Over - Winner: ${gameState.winner}`}
                 {gameState.tableStatus === "PLAYING" && (
@@ -64,26 +72,30 @@ export const PokerTable: React.FC<PokerTableProps> = ({
                   </>
                 )}
               </div>
-              {/* Pot and current bet */}
-              <div className="pot">
-                <div>POT: ${formatChips(gameState.pot)}</div>
-                {gameState.round.currentBet > 0 && (
-                  <div className="current-bet">Current Bet: ${formatChips(gameState.round.currentBet)}</div>
-                )}
-                {gameState.round.roundPot > 0 && (
-                  <div className="round-pot">Round Pot: ${formatChips(gameState.round.roundPot)}</div>
-                )}
-              </div>
-              {/* Community cards */}
-              <div className="river">
-                {gameState?.community?.map((card, index) => (
-                  <Card key={`${card.rank}-${card.suit}-${index}`} card={card} />
-                ))}
-                {/* Empty cards to complete 5 */}
-                {Array.from({ length: Math.max(0, 5 - gameState.community.length) }).map((_, index) => (
-                  <Card key={`empty-${index}`} card={null} />
-                ))}
-              </div>
+              {ready && (
+                <>
+                  {/* Pot and current bet */}
+                  <div className="pot">
+                    <div>POT: ${formatChips(gameState.pot)}</div>
+                    {gameState.round?.currentBet > 0 && (
+                      <div className="current-bet">Current Bet: ${formatChips(gameState.round.currentBet)}</div>
+                    )}
+                    {gameState.round?.roundPot > 0 && (
+                      <div className="round-pot">Round Pot: ${formatChips(gameState.round.roundPot)}</div>
+                    )}
+                  </div>
+                  {/* Community cards */}
+                  <div className="river">
+                    {gameState?.community?.map((card, index) => (
+                      <Card key={`${card.rank}-${card.suit}-${index}`} card={card} />
+                    ))}
+                    {/* Empty cards to complete 5 */}
+                    {Array.from({ length: Math.max(0, 5 - gameState?.community?.length) }).map((_, index) => (
+                      <Card key={`empty-${index}`} card={null} />
+                    ))}
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/packages/poker-state-machine/src/queries.ts
+++ b/packages/poker-state-machine/src/queries.ts
@@ -10,9 +10,19 @@ export function firstPlayerIndex(state: PokerState): number {
   const players = state.players.length
   const preflop = state.community.length === 0
   const dealerIndex = findDealerIndex(state)
-  return players === 2 && preflop
-    ? dealerIndex
-    : (dealerIndex + 3) % players
+  
+  if (players === 2) {
+    // In Heads-up:
+    // - Pre-flop: Dealer (SB) acts first
+    // - Post-flop: BB (non-dealer) acts first
+    return preflop 
+      ? dealerIndex  // Dealer acts first in pre-flop
+      : (dealerIndex + 1) % 2  // BB acts first after pre-flop
+  }
+  
+  // In regular game (3+ players):
+  // First to act is the position after BB (UTG)
+  return (dealerIndex + 3) % players
 }
 
 export function rotated<T>(array: readonly T[], count: number): readonly T[] {
@@ -23,7 +33,12 @@ export function roundRotation(state: PokerState): readonly PlayerState[] {
     return rotated(state.players, state.players.length - firstPlayerIndex(state))
 }
 
-export const currentPlayer = (state: PokerState) => state.players[state.currentPlayerIndex]
+export const currentPlayer = (state: PokerState) => {
+    if (state.currentPlayerIndex < 0 || state.currentPlayerIndex >= state.players.length) {
+        return null;
+    }
+    return state.players[state.currentPlayerIndex];
+}
 
 export const smallBlind = (state: PokerState) => {
     const dealerIndex = findDealerIndex(state)

--- a/packages/poker-state-machine/src/room.ts
+++ b/packages/poker-state-machine/src/room.ts
@@ -64,7 +64,6 @@ function computeNextState(
             return nextRound(state).pipe(
                 Effect.map(newState => ({
                     ...newState,
-                    lastMove: null
                 }))
             )
         }
@@ -72,7 +71,7 @@ function computeNextState(
             return endGame(state).pipe(
                 Effect.map(newState => ({
                     ...newState,
-                    lastMove: null
+                    //lastMove: null
                 }))
             )
         }

--- a/packages/poker-state-machine/src/room.ts
+++ b/packages/poker-state-machine/src/room.ts
@@ -30,17 +30,33 @@ function computeNextState(
 ): Effect.Effect<PokerState, ProcessEventError, never> {
     switch (event.type) {
         case 'table': {
-            if (state.tableStatus === 'PLAYING') {
-                return Effect.fail<ProcessEventError>({ type: 'table_locked' })
-            }
-            switch (event.action) {
-                case 'join': return Effect.succeed({...addPlayer(state, event.playerId, event.playerName), lastMove: null})
-                case 'leave': return Effect.succeed({...removePlayer(state, event.playerId), lastMove: null})
-            }
+          const playerPlaying = state.players.find(p => p.id === event.playerId)
+          if (playerPlaying) {
+              return Effect.succeed({...state})
+          }
+          if (state.tableStatus === "PLAYING") {
+            return Effect.fail<ProcessEventError>({ type: "table_locked" });
+          }
+          switch (event.action) {
+            case "join":
+              return Effect.succeed({
+                ...addPlayer(state, event.playerId, event.playerName),
+                lastMove: null,
+              });
+            case "leave":
+              return Effect.succeed({
+                ...removePlayer(state, event.playerId),
+                lastMove: null,
+              });
+          }
         }
         case 'move': {
-            if (event.playerId !== currentPlayer(state).id) {
-                return Effect.fail<ProcessEventError>({ type: 'not_your_turn' })
+            const current = currentPlayer(state);
+            if (!current) {
+                return Effect.fail<ProcessEventError>({ type: 'not_your_turn' });
+            }
+            if (event.playerId !== current.id) {
+                return Effect.fail<ProcessEventError>({ type: 'not_your_turn' });
             }
             // Store the move event
             return processPlayerMove(state, event.move).pipe(
@@ -48,7 +64,7 @@ function computeNextState(
                     ...newState,
                     lastMove: event
                 }))
-            )
+            );
         }
         case 'start': {
             // console.log('computeNextState', { event })
@@ -57,7 +73,7 @@ function computeNextState(
             // TODO: sanity check for status?
             // return Effect.succeed(startRound(state))
         }
-        case 'transition_phase': {
+        case 'transition_phase': { // not used
             return transition(state)
         }
         case 'next_round': {

--- a/packages/poker-state-machine/src/schemas.ts
+++ b/packages/poker-state-machine/src/schemas.ts
@@ -31,6 +31,7 @@ export const PlayerStateSchema = Schema.Struct({
   id: Schema.String,
   playerName: Schema.String,
   status: PlayerStatusSchema,
+  playedThisPhase: Schema.Boolean,
   hand: Schema.Union(Schema.Tuple(), HoleCardsSchema),
   chips: Schema.Number,
   bet: Schema.Struct({

--- a/packages/poker-state-machine/src/state_machine.ts
+++ b/packages/poker-state-machine/src/state_machine.ts
@@ -21,7 +21,7 @@ export const POKER_ROOM_DEFAULT_STATE: PokerState = {
   winner: null,
   config: {
     maxRounds: null,
-    startingChips: 100,
+    startingChips: 1000,
     smallBlind: 10,
     bigBlind: 20,
   },
@@ -30,7 +30,8 @@ export const POKER_ROOM_DEFAULT_STATE: PokerState = {
 export const PLAYER_DEFAULT_STATE: Omit<PlayerState, "id"> = {
   status: "PLAYING",
   hand: [],
-  chips: 100,
+  chips: 1000,
+  playedThisPhase: false,
   bet: { round: 0, total: 0 },
   playerName: "",
 };

--- a/packages/poker-state-machine/test/all_in.test.ts
+++ b/packages/poker-state-machine/test/all_in.test.ts
@@ -129,16 +129,16 @@ describe('All-in functionality', () => {
     const callState = playerBet(initialState, 'player1', 40);
     
     // Looking at the playerBet implementation, the pot gets increased by the diff, not the total
-    // The initial pot is 20, the player adds 20 more (diff between 40 and the current bet of 20)
-    // So the final pot should be 40 (initial 20 + diff of 20)
-    expect(callState.pot).toBe(40); 
-    expect(callState.round.currentBet).toBe(40);
+    // The initial pot is 20, the player tries to add 40 more but only has 30 chips
+    // So the final pot should be 50 (initial 20 + all remaining 30 chips)
+    expect(callState.pot).toBe(50);
+    expect(callState.round.currentBet).toBe(50);
     
     const callingPlayer = callState.players.find((p: PlayerState) => p.id === 'player1');
-    expect(callingPlayer?.chips).toBe(10); // Started with 30, bet 20 more
-    expect(callingPlayer?.status).toBe('PLAYING'); // Still has chips left
-    expect(callingPlayer?.bet.round).toBe(40); // 20 initial + 20 more to reach 40
-    expect(callingPlayer?.bet.total).toBe(40); // 20 initial + 20 more
+    expect(callingPlayer?.chips).toBe(0); // Used all remaining chips
+    expect(callingPlayer?.status).toBe('ALL_IN'); // Went all-in
+    expect(callingPlayer?.bet.round).toBe(50); // 20 initial + 30 more
+    expect(callingPlayer?.bet.total).toBe(50); // 20 initial + 30 more
   });
 
   test('all-in with player who already bet some chips', () => {

--- a/packages/poker-state-machine/test/full_game_flow.test.ts
+++ b/packages/poker-state-machine/test/full_game_flow.test.ts
@@ -6,24 +6,28 @@ import { makePokerRoomForTests } from "../src/room";
 import { playerBet } from "../src/transitions";
 import type { GameEvent, PlayerState, PokerState, RoundState, SystemEvent } from "../src/schemas";
 
-describe('Poker game flow tests', () => {
+describe("Poker game flow tests", () => {
   // Unique player IDs to avoid duplication issues in the original test
-  const PLAYER_IDS = ['player1', 'player2', 'player3'];
-  
+  const PLAYER_IDS = ["player1", "player2", "player3"];
+
   // Helper function to create a test player
-  function createPlayer(id: string, chips = 100, status: 'PLAYING' | 'FOLDED' | 'ALL_IN' = 'PLAYING'): PlayerState {
+  function createPlayer(
+    id: string,
+    chips = 1000,
+    status: "PLAYING" | "FOLDED" | "ALL_IN" = "PLAYING"
+  ): PlayerState {
     return {
       ...PLAYER_DEFAULT_STATE,
       id,
       chips,
       playerName: `Player ${id}`,
-      status
+      status,
     };
   }
-  
+
   // Define the expected state shape with proper typing for partial objects
   type ExpectedState = {
-    tableStatus?: PokerState['tableStatus'];
+    tableStatus?: PokerState["tableStatus"];
     players?: Partial<PlayerState>[];
     currentPlayerIndex?: number;
     deck?: { length: number };
@@ -32,56 +36,64 @@ describe('Poker game flow tests', () => {
     round?: Partial<RoundState>;
     dealerId?: string;
     winner?: string | null;
-    config?: PokerState['config'];
+    config?: PokerState["config"];
   };
-  
+
   // Helper function to create a more flexible assertion for comparing state objects
   // Allowing partial matches to reduce test brittleness
   function compareStates(actual: PokerState, expected: ExpectedState): void {
     // For each key in expected, check if the actual value matches
     for (const [key, value] of Object.entries(expected)) {
-      if (key === 'players') {
+      if (key === "players") {
         // Special handling for players array
         const expectedPlayers = value as Partial<PlayerState>[];
         expect(actual.players.length).toBe(expectedPlayers.length);
-        
+
         for (let i = 0; i < expectedPlayers.length; i++) {
           const expectedPlayer = expectedPlayers[i];
           const actualPlayer = actual.players[i];
-          
+
           // For each player, check the specified properties
-          for (const [playerKey, playerValue] of Object.entries(expectedPlayer)) {
-            if (playerKey === 'hand') {
+          for (const [playerKey, playerValue] of Object.entries(
+            expectedPlayer
+          )) {
+            if (playerKey === "hand") {
               // For hand, just verify the length if specified
               if (playerValue) {
-                expect(actualPlayer.hand.length).toBe((playerValue as any).length);
+                expect(actualPlayer.hand.length).toBe(
+                  (playerValue as any).length
+                );
               }
             } else {
-              expect(actualPlayer[playerKey as keyof PlayerState]).toEqual(playerValue);
+              expect(actualPlayer[playerKey as keyof PlayerState]).toEqual(
+                playerValue
+              );
             }
           }
         }
-      } else if (key === 'community') {
+      } else if (key === "community") {
         // For community cards, just verify the length if specified
-        if (value && typeof value === 'object' && 'length' in value) {
+        if (value && typeof value === "object" && "length" in value) {
           expect(actual.community.length).toBe(value.length);
         }
-      } else if (key === 'deck') {
+      } else if (key === "deck") {
         // For deck, just verify the length if specified
-        if (value && typeof value === 'object' && 'length' in value) {
+        if (value && typeof value === "object" && "length" in value) {
           // Allow explicit numbers or use expect.any() for more flexibility
-          if (typeof value.length === 'number') {
+          if (typeof value.length === "number") {
             expect(actual.deck.length).toBe(value.length);
           } else {
             // For expect.any(), just check that the deck has cards
             expect(actual.deck.length).toBeGreaterThan(0);
           }
         }
-      } else if (key === 'round') {
+      } else if (key === "round") {
         // Special handling for round object, which needs full type safety
         const expectedRound = value as Partial<RoundState>;
         for (const [roundKey, roundValue] of Object.entries(expectedRound)) {
-          expect(actual.round[roundKey as keyof RoundState]).toEqual(roundValue);
+          expect(actual.round[roundKey as keyof RoundState]).toEqual(
+            roundValue
+          );
         }
       } else {
         // For all other properties, do direct comparison
@@ -89,28 +101,28 @@ describe('Poker game flow tests', () => {
       }
     }
   }
-  
-  test('Initial state should be empty waiting state', async () => {
+
+  test("Initial state should be empty waiting state", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
     const state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Initial state verification
-    expect(state).toEqual({...POKER_ROOM_DEFAULT_STATE, tableId: 'table-id'});
+    expect(state).toEqual({ ...POKER_ROOM_DEFAULT_STATE, tableId: "table-id" });
   });
-  
-  test('Player 1 joining should update state correctly', async () => {
+
+  test("Player 1 joining should update state correctly", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
+
     // Step 1: Player 1 joins
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
+        type: "table",
         playerName: PLAYER_IDS[0],
-        action: 'join',
-        playerId: PLAYER_IDS[0]
+        action: "join",
+        playerId: PLAYER_IDS[0],
       })
     );
-    
+
     const state = await Effect.runPromise(pokerRoom.currentState());
     compareStates(state, {
       tableStatus: "WAITING",
@@ -118,7 +130,7 @@ describe('Poker game flow tests', () => {
         {
           id: PLAYER_IDS[0],
           status: "PLAYING",
-          chips: 100,
+          chips: 1000,
           playerName: PLAYER_IDS[0],
           hand: [],
           bet: { round: 0, total: 0 },
@@ -126,92 +138,94 @@ describe('Poker game flow tests', () => {
       ],
     });
   });
-  
-  test('Two players joining should start the game', async () => {
+
+  test("Two players joining should start the game", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
+
     // Player 1 joins
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[0],
-        playerName: PLAYER_IDS[0]
+        playerName: PLAYER_IDS[0],
       })
     );
-    
+
     // Player 2 joins
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[1],
-        playerName: PLAYER_IDS[1]
+        playerName: PLAYER_IDS[1],
       })
     );
-    
+
     const state = await Effect.runPromise(pokerRoom.currentState());
     compareStates(state, {
       tableStatus: "PLAYING",
-      round: { 
+      round: {
         phase: "PRE_FLOP",
         roundNumber: 1,
-        currentBet: 20
+        currentBet: 20,
       },
       pot: 30, // Small blind (10) + Big blind (20)
       players: [
         {
           id: PLAYER_IDS[0],
-          status: 'PLAYING',
-          chips: 90, // 100 - small blind (10)
+          status: "PLAYING",
+          chips: 990, // 1000 - 10 total
           bet: { round: 10, total: 10 },
           playerName: PLAYER_IDS[0],
-          hand: [expect.any(Object), expect.any(Object)]
+          hand: [expect.any(Object), expect.any(Object)],
         },
         {
           id: PLAYER_IDS[1],
           status: "PLAYING",
-          chips: 80, // 100 - big blind (20)
+          chips: 980,
           bet: { round: 20, total: 20 },
           playerName: PLAYER_IDS[1],
-          hand: [expect.any(Object), expect.any(Object)]
-        }
+          hand: [expect.any(Object), expect.any(Object)],
+        },
       ],
       community: { length: 0 },
-      deck: { length: 48 } // 52 cards - 4 cards dealt to players = 48 cards remaining
+      deck: { length: 48 }, // 52 cards - 4 cards dealt to players = 48 cards remaining
     });
-    
+
     // Verify dealer and blinds are set correctly
     expect(smallBlind(state).id).toBe(PLAYER_IDS[0]);
     expect(bigBlind(state).id).toBe(PLAYER_IDS[1]);
-    
+
     // Verify first player to act (small blind in heads-up)
+    const current = currentPlayer(state);
+    expect(current).not.toBeNull();
     expect(firstPlayerIndex(state)).toBe(0);
-    expect(currentPlayer(state).id).toBe(PLAYER_IDS[0]);
+    expect(current!.id).toBe(PLAYER_IDS[0]);
   });
-  
-  test('Player calling should progress the game to next betting round', async () => {
+
+  test("Player calling should progress the game to next betting round", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
+
     // Setup: Two players join
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[0],
-        playerName: PLAYER_IDS[0]
+        playerName: PLAYER_IDS[0],
       })
     );
-    
+
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[1],
-        playerName: PLAYER_IDS[1]
+        playerName: PLAYER_IDS[1],
       })
     );
-    
+
     // Step 3: Player 1 calls the big blind
     await Effect.runPromise(
       pokerRoom.processEvent({
@@ -220,49 +234,49 @@ describe('Poker game flow tests', () => {
         move: { type: "call", decisionContext: null },
       })
     );
-    
+
     // Get state after player 1's call
     let state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Check if we're still in pre-flop or already moved to flop
-    if (state.round.phase === 'PRE_FLOP') {
+    if (state.round.phase === "PRE_FLOP") {
       compareStates(state, {
         pot: 40, // Small blind (10) + Big blind (20) + Call (10)
         currentPlayerIndex: 1,
         players: [
           {
             id: PLAYER_IDS[0],
-            status: 'PLAYING',
-            chips: 80, // 100 - 20 total
-            bet: { round: 20, total: 20 }
+            status: "PLAYING",
+            chips: 980, // 1000 - 20 total
+            bet: { round: 20, total: 20 },
           },
           {
             id: PLAYER_IDS[1],
-            status: 'PLAYING',
-            chips: 80,
-            bet: { round: 20, total: 20 }
-          }
-        ]
+            status: "PLAYING",
+            chips: 980,
+            bet: { round: 20, total: 20 },
+          },
+        ],
       });
-      
+
       // Player 2 checks, should transition to FLOP
       await Effect.runPromise(
         pokerRoom.processEvent({
-          type: 'move',
+          type: "move",
           playerId: PLAYER_IDS[1],
-          move: { type: 'call', decisionContext: null }
+          move: { type: "call", decisionContext: null },
         })
       );
-      
+
       state = await Effect.runPromise(pokerRoom.currentState());
     }
-    
+
     // Now we should be in the FLOP phase
     compareStates(state, {
-      round: { 
-        phase: 'FLOP', 
+      round: {
+        phase: "FLOP",
         currentBet: 0,
-        roundNumber: 1
+        roundNumber: 1,
       },
       pot: 40, // Same pot from preflop
       community: { length: 3 }, // Should have 3 community cards
@@ -271,338 +285,513 @@ describe('Poker game flow tests', () => {
         {
           id: PLAYER_IDS[0],
           bet: { round: 0, total: 20 }, // Reset round bet to 0 in new phase
-          chips: 80
+          chips: 980,
         },
         {
           id: PLAYER_IDS[1],
           bet: { round: 0, total: 20 }, // Reset round bet to 0 in new phase
-          chips: 80
-        }
-      ]
+          chips: 980,
+        },
+      ],
     });
-    
+
     // In the actual implementation, player 2 acts first after flop
-    expect(currentPlayer(state).id).toBe(PLAYER_IDS[1]);
+    const current = currentPlayer(state);
+    expect(current).not.toBeNull();
+    expect(current!.id).toBe(PLAYER_IDS[1]);
   });
-  
-  test('Checking on the flop should progress to the turn', async () => {
+
+  test("Checking on the flop should progress to the turn", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
+
     // Setup: Two players join and go through pre-flop
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'table', action: 'join', playerId: PLAYER_IDS[0], playerName: PLAYER_IDS[0] }));
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'table', action: 'join', playerId: PLAYER_IDS[1], playerName: PLAYER_IDS[1] }));
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[0], move: { type: 'call', decisionContext: null } }));
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[1], move: { type: 'call', decisionContext: null } }));
-    
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[0],
+        playerName: PLAYER_IDS[0],
+      })
+    );
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[1],
+        playerName: PLAYER_IDS[1],
+      })
+    );
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "call", decisionContext: null },
+      })
+    );
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
     // At this point we should be at the flop, Player 2 acts first
     let state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Player 2 checks on the flop
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'move',
+        type: "move",
         playerId: PLAYER_IDS[1],
-        move: { type: 'call', decisionContext: null }
+        move: { type: "call", decisionContext: null },
       })
     );
-    
+
     // Check if we've transitioned to turn or still on flop
     state = await Effect.runPromise(pokerRoom.currentState());
-    
-    if (state.round.phase === 'FLOP') {
+
+    if (state.round.phase === "FLOP") {
       // Player 1 checks, should transition to TURN
       await Effect.runPromise(
         pokerRoom.processEvent({
-          type: 'move',
+          type: "move",
           playerId: PLAYER_IDS[0],
-          move: { type: 'call', decisionContext: null }
+          move: { type: "call", decisionContext: null },
         })
       );
-      
+
       state = await Effect.runPromise(pokerRoom.currentState());
     }
-    
+
     // Now we should be in the next phase (either TURN or RIVER)
     // Get the actual phase instead of hard-coding it
     const nextPhase = state.round.phase;
-    
+
     compareStates(state, {
-      round: { 
-        phase: nextPhase, 
+      round: {
+        phase: nextPhase,
         currentBet: 0,
-        roundNumber: 1
+        roundNumber: 1,
       },
       pot: 40,
-      community: { length: nextPhase === 'TURN' ? 4 : 5 }, // 4 cards for TURN, 5 for RIVER
-      deck: { length: nextPhase === 'TURN' ? 44 : 43 } // 45-1=44 for TURN, 45-2=43 for RIVER
+      community: { length: nextPhase === "TURN" ? 4 : 5 }, // 4 cards for TURN, 5 for RIVER
+      deck: { length: nextPhase === "TURN" ? 44 : 43 }, // 45-1=44 for TURN, 45-2=43 for RIVER
     });
-    
+
     // On turn/river, the first player to act is player 2
-    expect(currentPlayer(state).id).toBe(PLAYER_IDS[1]);
+    const current = currentPlayer(state);
+    expect(current).not.toBeNull();
+    expect(current!.id).toBe(PLAYER_IDS[1]);
   });
-  
-  test('Betting on the turn should update the pot and bets', async () => {
+
+  test("Betting on the turn should update the pot and bets", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
+
     // Setup: Players join and play through to the turn
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'table', action: 'join', playerId: PLAYER_IDS[0], playerName: PLAYER_IDS[0] }));
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'table', action: 'join', playerId: PLAYER_IDS[1], playerName: PLAYER_IDS[1] }));
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[0], move: { type: 'call', decisionContext: null } }));
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[1], move: { type: 'call', decisionContext: null } }));
-    
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[0],
+        playerName: PLAYER_IDS[0],
+      })
+    );
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[1],
+        playerName: PLAYER_IDS[1],
+      })
+    );
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "call", decisionContext: null },
+      })
+    );
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
     // Get the state to see which phase we're in
     let state = await Effect.runPromise(pokerRoom.currentState());
-    
-    // If we're still in FLOP, have both players check
-    if (state.round.phase === 'FLOP') {
-      await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[1], move: { type: 'call', decisionContext: null } }));
-      await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[0], move: { type: 'call', decisionContext: null } }));
-    }
-    
-    // Check the current state and phase
-    state = await Effect.runPromise(pokerRoom.currentState());
-    // console.log(`Current phase: ${state.round.phase}, current player: ${currentPlayer(state).id}`);
-    
-    // Player 2 bets 20 on the turn (make sure player 2 is the current player)
-    if (currentPlayer(state).id === PLAYER_IDS[1]) {
+
+    // Play through each betting round correctly
+    const playBettingRound = async () => {
+      state = await Effect.runPromise(pokerRoom.currentState());
+      const currentPhase = state.round.phase;
+
+      // First player acts
+      const current = currentPlayer(state);
+      expect(current).not.toBeNull();
+      
       await Effect.runPromise(
         pokerRoom.processEvent({
-          type: 'move',
+          type: "move",
+          playerId: current!.id,
+          move: { type: "call", decisionContext: null },
+        })
+      );
+
+      // Get updated state
+      state = await Effect.runPromise(pokerRoom.currentState());
+
+      // Second player acts if it's their turn
+      if (state.round.phase === currentPhase) {
+        const nextPlayer = currentPlayer(state);
+        expect(nextPlayer).not.toBeNull();
+        
+        await Effect.runPromise(
+          pokerRoom.processEvent({
+            type: "move",
+            playerId: nextPlayer!.id,
+            move: { type: "call", decisionContext: null },
+          })
+        );
+      }
+    };
+
+    // Play through FLOP if we're in that phase
+    if (state.round.phase === "FLOP") {
+      await playBettingRound();
+    }
+
+    // Get updated state
+    state = await Effect.runPromise(pokerRoom.currentState());
+
+    // Check the current state and phase
+    // console.log(`Current phase: ${state.round.phase}, current player: ${currentPlayer(state).id}`);
+    console.log("State 1111:", {
+      phase: state.round.phase,
+      currentPlayer: currentPlayer(state)!.id,
+    });
+    // Player 2 bets 20 on the turn (make sure player 2 is the current player)
+    if (currentPlayer(state)!.id === PLAYER_IDS[1]) {
+      console.log("Player 2 is current player, betting 20");
+      await Effect.runPromise(
+        pokerRoom.processEvent({
+          type: "move",
           playerId: PLAYER_IDS[1],
-          move: { type: 'raise', amount: 20, decisionContext: null }
+          move: { type: "raise", amount: 20, decisionContext: null }, // Aposta 20 novo
         })
       );
     } else {
-      // If player 1 is current player, let them check first
-      await Effect.runPromise(
-        pokerRoom.processEvent({
-          type: 'move',
-          playerId: PLAYER_IDS[0],
-          move: { type: 'call', decisionContext: null }
-        })
-      );
-      
-      // Now player 2 should be able to bet
-      await Effect.runPromise(
-        pokerRoom.processEvent({
-          type: 'move',
-          playerId: PLAYER_IDS[1],
-          move: { type: 'raise', amount: 20, decisionContext: null }
-        })
-      );
+        // If player 1 is current player, let them check first
+        await Effect.runPromise(
+            pokerRoom.processEvent({
+                type: "move",
+                playerId: PLAYER_IDS[0],
+                move: { type: "call", decisionContext: null },
+            })
+        );
+
+        // Now player 2 should be able to bet
+        await Effect.runPromise(
+            pokerRoom.processEvent({
+                type: "move",
+                playerId: PLAYER_IDS[1],
+                move: { type: "raise", amount: 20, decisionContext: null }, // Aposta 20 novo
+            })
+        );
     }
-    
+
     state = await Effect.runPromise(pokerRoom.currentState());
     compareStates(state, {
-      round: { 
-        currentBet: 20
+      round: {
+        currentBet: 20,
       },
       pot: 60, // 40 + 20
       players: [
         {
           id: PLAYER_IDS[0],
           bet: { round: 0, total: 20 },
-          chips: 80
+          chips: 980,
         },
         {
           id: PLAYER_IDS[1],
-          chips: 60, // 80 - 20
-          bet: { round: 20, total: 40 }
-        }
-      ]
+          chips: 960, // 980 - 20
+          bet: { round: 20, total: 40 },
+        },
+      ],
     });
-    
+
     // Verify current player is now player 1
-    expect(currentPlayer(state).id).toBe(PLAYER_IDS[0]);
+    expect(currentPlayer(state)!.id).toBe(PLAYER_IDS[0]);
   });
-  
-  test('Folding should end the round and award pot to opponent', async () => {
+
+  test("Folding should end the round and award pot to opponent", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
-    // Setup: Players join and play through to the turn with a bet
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'table', action: 'join', playerId: PLAYER_IDS[0], playerName: PLAYER_IDS[0] }));
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'table', action: 'join', playerId: PLAYER_IDS[1], playerName: PLAYER_IDS[1] }));
-    
-    // Play to the turn and have player 2 bet
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[0], move: { type: 'call', decisionContext: null } }));
-    await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[1], move: { type: 'call', decisionContext: null } }));
-    
-    // Move to turn phase by both players checking on flop
+
+    // Setup: Players join
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[0],
+        playerName: PLAYER_IDS[0],
+      })
+    );
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[1],
+        playerName: PLAYER_IDS[1],
+      })
+    );
+
+    // Get initial state
     let state = await Effect.runPromise(pokerRoom.currentState());
-    if (state.round.phase === 'FLOP') {
-      await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[1], move: { type: 'call', decisionContext: null } }));
-      await Effect.runPromise(pokerRoom.processEvent({ type: 'move', playerId: PLAYER_IDS[0], move: { type: 'call', decisionContext: null } }));
-    }
-    
-    // Get updated state
-    state = await Effect.runPromise(pokerRoom.currentState());
-    
-    // Make sure we're on turn and Player 2 is current player
-    if (state.round.phase !== 'TURN' || currentPlayer(state).id !== PLAYER_IDS[1]) {
-      // console.log(`Current phase: ${state.round.phase}, current player: ${currentPlayer(state).id}`);
-      // Adjust if needed...
-    }
-    
-    // Player 2 raises
-    await Effect.runPromise(
+    const initialRoundNumber = state.round.roundNumber;
+
+    // PRE-FLOP: SB calls BB
+    state =await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'move',
-        playerId: currentPlayer(state).id,
-        move: { type: 'raise', amount: 20, decisionContext: null }
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "call", decisionContext: null },
       })
     );
-    
+    console.log("State rrr1:", {
+      phase: state.round.phase,
+      currentPlayer: currentPlayer(state)!.id,
+      players: state.players.map((p) => ({
+        id: p.id,
+        playedThisPhase: p.playedThisPhase,
+      })),
+    });
     state = await Effect.runPromise(pokerRoom.currentState());
-    
-    // Player 1 folds (should be current player now)
+    console.log("State rrr2:", {
+      phase: state.round.phase,
+      currentPlayer: currentPlayer(state)!.id,
+      players: state.players.map(p => ({
+        id: p.id,
+        playedThisPhase: p.playedThisPhase,
+      })),
+    });
+    expect(state.round.phase).toBe("PRE_FLOP");
+    expect(state.players[0].playedThisPhase).toBe(true);
+    expect(state.players[1].playedThisPhase).toBe(false);
+    console.log("State zzzz:", {
+      phase: state.round.phase,
+      currentPlayer: currentPlayer(state)!.id,
+      players: state.players.map(p => ({
+        id: p.id,
+        playedThisPhase: p.playedThisPhase,
+      })),
+    });
+
+    // BB checks (explicitly acts to mark playedThisPhase)
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'move',
-        playerId: currentPlayer(state).id,
-        move: { type: 'fold', decisionContext: null }
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "call", decisionContext: null },
       })
     );
-    
+
+    // Get state at FLOP
     state = await Effect.runPromise(pokerRoom.currentState());
+    console.log("State XXXX:", {
+      phase: state.round.phase,
+      currentPlayer: currentPlayer(state)!.id,
+      players: state.players.map((p) => ({
+        id: p.id,
+        playedThisPhase: p.playedThisPhase,
+      })),
+    });
+    expect(state.round.phase).toBe("FLOP");
     
-    // Log the actual state for debugging
-    // console.log('After fold, actual state:', {
-    //   status: state.tableStatus,
-    //   pot: state.pot,
-    //   round: state.round,
-    //   winner: state.winner,
-    //   player1Chips: state.players.find(p => p.id === PLAYER_IDS[0])?.chips,
-    //   player2Chips: state.players.find(p => p.id === PLAYER_IDS[1])?.chips
-    // });
-    
-    // Check that player 2 got the chips from the pot
-    // Instead of checking the status, we verify that player 2's chips increased
-    const player2 = state.players.find(p => p.id === PLAYER_IDS[1]);
-    expect(player2?.chips).toBeGreaterThanOrEqual(100); // Player 2 should have at least starting chips
+    // FLOP: BB bets first
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "raise", amount: 20, decisionContext: null },
+      })
+    );
+
+    // Record pot size and player chips before fold
+    state = await Effect.runPromise(pokerRoom.currentState());
+    const potBeforeFold = state.pot;
+    const bbPlayer = state.players.find((p) => p.id === PLAYER_IDS[1]);
+    const sbPlayer = state.players.find((p) => p.id === PLAYER_IDS[0]);
+
+    // Ensure we found both players
+    expect(bbPlayer).not.toBeUndefined();
+    expect(sbPlayer).not.toBeUndefined();
+
+    const bbChipsBeforeFold = bbPlayer!.chips;
+    const sbChipsBeforeFold = sbPlayer!.chips;
+
+    // SB (Player1) folds
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "fold", decisionContext: null },
+      })
+    );
+
+    // Get state after fold (which should be the new round already)
+    state = await Effect.runPromise(pokerRoom.currentState());
+
+    // Verify we're in a new round
+    expect(state.round.roundNumber).toBe(initialRoundNumber + 1);
+    expect(state.tableStatus).toBe("PLAYING"); // Should be ready for new round
+    expect(state.round.phase).toBe("PRE_FLOP"); // New round starts at pre-flop
+
+    // Verify pot has blinds for new round
+    expect(state.pot).toBe(30); // New round starts with SB (10) + BB (20)
+
+    // Verify BB got the pot from previous round and paid new blind
+    const bbPlayerAfter = state.players.find((p) => p.id === PLAYER_IDS[1]);
+    expect(bbPlayerAfter).not.toBeUndefined();
+    // BB won previous pot but paid new blind (either SB or BB)
+    expect(bbPlayerAfter!.chips).toBeGreaterThan(bbChipsBeforeFold); // Should have more chips even after paying new blind
+
+    // Verify SB lost their chips from previous round and paid new blind
+    const sbPlayerAfter = state.players.find((p) => p.id === PLAYER_IDS[0]);
+    expect(sbPlayerAfter).not.toBeUndefined();
+    expect(sbPlayerAfter!.chips).toBeLessThan(sbChipsBeforeFold); // Should have less chips after losing and paying new blind
+
+    // Verify both players have appropriate bets for new round
+    state.players.forEach((player) => {
+      expect(player.status).toBe("PLAYING"); // Both should be PLAYING for next round
+      expect(player.bet.round).toBeGreaterThan(0); // Should have paid blind
+      expect(player.bet.total).toBeGreaterThan(0); // Should have paid blind
+    });
   });
-  
-  test('Player can only join when game is in WAITING state', async () => {
+
+  test("Player can only join when game is in WAITING state", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2)); // Allow 3 players for this test
-    
+
     // First player joins successfully when state is WAITING
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[0],
-        playerName: PLAYER_IDS[0]
+        playerName: PLAYER_IDS[0],
       })
     );
-    
+
     // Second player joins successfully when state is still WAITING
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[1],
-        playerName: PLAYER_IDS[1]
+        playerName: PLAYER_IDS[1],
       })
     );
-    
+
     // Get state to verify we're now in PLAYING state
     const state = await Effect.runPromise(pokerRoom.currentState());
-    expect(state.tableStatus).toBe('PLAYING');
-    
+    expect(state.tableStatus).toBe("PLAYING");
+
     // Verify players are in the state correctly
     expect(state.players.length).toBe(2);
     expect(state.players[0].id).toBe(PLAYER_IDS[0]);
     expect(state.players[1].id).toBe(PLAYER_IDS[1]);
-    
+
     // Attempt to join a third player while PLAYING - this should throw
     let joinError = null;
     try {
       await Effect.runPromise(
         pokerRoom.processEvent({
-          type: 'table',
-          action: 'join',
+          type: "table",
+          action: "join",
           playerId: PLAYER_IDS[2],
-          playerName: PLAYER_IDS[2]
+          playerName: PLAYER_IDS[2],
         })
       );
     } catch (error) {
       joinError = error;
       // console.log('As expected, could not join during active game:', error);
     }
-    
+
     // Verify that attempting to join failed
     expect(joinError).not.toBeNull();
   });
 
-  test('Showdown - Two players should compare hands at the river', async () => {
+  test("Showdown - Two players should compare hands at the river", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
+
     // Setup: Two players join
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[0],
-        playerName: PLAYER_IDS[0]
+        playerName: PLAYER_IDS[0],
       })
     );
-    
+
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[1],
-        playerName: PLAYER_IDS[1]
+        playerName: PLAYER_IDS[1],
       })
     );
-    
+
     // Get state once the table setup is complete (this is before blinds are posted)
     let state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Play through all betting phases (PRE_FLOP, FLOP, TURN, RIVER)
-    const phases = ['PRE_FLOP', 'FLOP', 'TURN', 'RIVER'];
-    
+    const phases = ["PRE_FLOP", "FLOP", "TURN", "RIVER"];
+
     // Wait for the PRE_FLOP phase to begin, then record the initial state
     // This ensures we're measuring after blinds have been posted
     let initialChips = 0;
     let initialPot = 0;
-    
+
     for (const phase of phases) {
       state = await Effect.runPromise(pokerRoom.currentState());
-      
+
       // Record initial state after blinds are posted
-      if (phase === 'PRE_FLOP' && initialChips === 0) {
+      if (phase === "PRE_FLOP" && initialChips === 0) {
         initialChips = state.players.reduce((sum, p) => sum + p.chips, 0);
         initialPot = state.pot;
         // console.log(`Initial chips: ${initialChips}, Initial pot: ${initialPot}, Total: ${initialChips + initialPot}`);
       }
-      
+
       // Make sure we're in the expected phase
       if (state.round.phase !== phase) {
         continue;
       }
-      
+
       // Have all active players check/call until the betting round is complete
       let bettingComplete = false;
       while (!bettingComplete) {
         state = await Effect.runPromise(pokerRoom.currentState());
-        
+
         // Check if there are active players
         if (state.currentPlayerIndex < 0) {
           bettingComplete = true;
           continue;
         }
-        
+
         const currentPlayerId = state.players[state.currentPlayerIndex].id;
-        
+
         // Player calls or checks
         await Effect.runPromise(
           pokerRoom.processEvent({
-            type: 'move',
+            type: "move",
             playerId: currentPlayerId,
-            move: { type: 'call', decisionContext: null }
+            move: { type: "call", decisionContext: null },
           })
         );
-        
+
         // Check if we've moved to the next phase
         const newState = await Effect.runPromise(pokerRoom.currentState());
         if (newState.round.phase !== phase) {
@@ -610,296 +799,358 @@ describe('Poker game flow tests', () => {
         }
       }
     }
-    
+
     // Get final state after all betting rounds
     state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // If we're still in RIVER phase, force showdown
-    if (state.round.phase === 'RIVER') {
+    if (state.round.phase === "RIVER") {
       await Effect.runPromise(
         pokerRoom.processEvent({
-          type: 'next_round'
+          type: "next_round",
         })
       );
     }
-    
+
     // Get final state after showdown
     state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Log final state for debugging
     const finalChips = state.players.reduce((sum, p) => sum + p.chips, 0);
     const finalPot = state.pot;
     // console.log(`Final chips: ${finalChips}, Final pot: ${finalPot}, Total: ${finalChips + finalPot}`);
     // console.log(`Round number: ${state.round.roundNumber}`);
-    
+
     // Don't strictly verify round number as it may depend on implementation
     // Just check that it has advanced from 1
     expect(state.round.roundNumber).toBeGreaterThan(1);
-    
+
     // Verify either that players' round bets are reset OR we're in a new round
-    state.players.forEach(player => {
-      const roundBetResetOrNewRound = player.bet.round === 0 || state.round.roundNumber > 1;
+    state.players.forEach((player) => {
+      const roundBetResetOrNewRound =
+        player.bet.round === 0 || state.round.roundNumber > 1;
       expect(roundBetResetOrNewRound).toBe(true);
     });
-    
+
     // Check that either:
     // 1. The pot is empty (distributed to players)
     // 2. OR at least one player has more chips than their initial amount
-    const hasPlayerWithMoreChips = state.players.some(player => {
-      return player.chips > 80; // Starting chips (100) - blinds or calls
+    const hasPlayerWithMoreChips = state.players.some((player) => {
+      return player.chips > 980; // Starting chips (1000) - blinds or calls
     });
-    
+
     expect(state.pot === 0 || hasPlayerWithMoreChips).toBe(true);
-    
+
     // Verify that total chips in the system are roughly conserved
     // (allow for minor rounding differences due to integer division)
     const totalFinalChips = finalChips + finalPot;
     const totalInitialChips = initialChips + initialPot;
-    expect(Math.abs(totalFinalChips - totalInitialChips)).toBeLessThanOrEqual(1);
+    expect(Math.abs(totalFinalChips - totalInitialChips)).toBeLessThanOrEqual(
+      1
+    );
   });
 
-  test('Dealer rotation - Dealer should rotate between rounds', async () => {
+  test("Dealer rotation - Dealer should rotate between rounds", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
+
     // Setup: Two players join
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[0],
-        playerName: PLAYER_IDS[0]
+        playerName: PLAYER_IDS[0],
       })
     );
-    
+
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[1],
-        playerName: PLAYER_IDS[1]
+        playerName: PLAYER_IDS[1],
       })
     );
-    
+
     // Start the game
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'start'
+        type: "start",
       })
     );
-    
+
     // Get the initial state to check first dealer
     let state = await Effect.runPromise(pokerRoom.currentState());
     const firstDealerId = state.dealerId;
     // console.log(`Initial dealer ID: ${firstDealerId}`);
-    
+
     // Play a quick round - first player folds
     const firstPlayerIndex = state.currentPlayerIndex;
     const firstPlayer = state.players[firstPlayerIndex];
-    
+
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'move',
+        type: "move",
         playerId: firstPlayer.id,
-        move: { type: 'fold', decisionContext: null }
+        move: { type: "fold", decisionContext: null },
       })
     );
-    
+
     // Explicitly start a new round
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'next_round'
+        type: "next_round",
       })
     );
-    
+
     // Start a new game to force dealer rotation
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'start'
+        type: "start",
       })
     );
-    
+
     // Get the state after the next round starts
     state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Check that dealer has rotated
     const secondDealerId = state.dealerId;
     // console.log(`New dealer ID: ${secondDealerId}`);
-    
+
     // Dealer should have changed
     expect(secondDealerId).not.toBe(firstDealerId);
-    
+
     // In heads-up poker, there are only two players, so if the dealer changed,
     // it must have rotated to the other player
-    const otherPlayerId = PLAYER_IDS.find(id => id !== firstDealerId);
+    const otherPlayerId = PLAYER_IDS.find((id) => id !== firstDealerId);
     expect(otherPlayerId).not.toBeUndefined();
     if (otherPlayerId) {
       expect(secondDealerId).toBe(otherPlayerId);
     }
   });
 
-  test('Multiple betting rounds - Raise and re-raise', async () => {
+  test("Multiple betting rounds - Raise and re-raise", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
-    
+
     // Setup: Two players join
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[0],
-        playerName: PLAYER_IDS[0]
+        playerName: PLAYER_IDS[0],
       })
     );
-    
+
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[1],
-        playerName: PLAYER_IDS[1]
+        playerName: PLAYER_IDS[1],
       })
     );
-    
-    // Start the game
-    await Effect.runPromise(
-      pokerRoom.processEvent({
-        type: 'start'
-      })
-    );
-    
-    // Get initial state to check who's the current player
+
+    // Get initial state and wait for PRE_FLOP phase
     let state = await Effect.runPromise(pokerRoom.currentState());
-    const firstToAct = state.currentPlayerIndex;
-    const firstPlayer = state.players[firstToAct];
-    const secondToAct = firstToAct === 0 ? 1 : 0;
-    const secondPlayer = state.players[secondToAct];
+    let attempts = 0;
+    const maxAttempts = 10;
+
+    // Wait until we're in PRE_FLOP and have a valid current player
+    while (attempts < maxAttempts) {
+        state = await Effect.runPromise(pokerRoom.currentState());
+        const current = currentPlayer(state);
+        
+        if (state.round.phase === "PRE_FLOP" && current && current.id) {
+            break;
+        }
+        
+        attempts++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Ensure we're in the correct phase and state
+    expect(state.round.phase).toBe("PRE_FLOP");
+    expect(state.tableStatus).toBe("PLAYING");
     
-    // Pre-flop: First player raises to 40
+    // Get current player and ensure it's valid
+    const current = currentPlayer(state);
+    if (!current || !current.id) {
+        throw new Error("No valid current player found after waiting");
+    }
+
+    // Player 1 (SB/Dealer) raises to 40
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'move',
-        playerId: firstPlayer.id,
-        move: { type: 'raise', amount: 40, decisionContext: null }
+        type: "move",
+        playerId: current.id,
+        move: { type: "raise", amount: 30, decisionContext: null }, // 10 (blind) + 30 = 40
       })
     );
-    
-    // Get updated state
+
+    // Get next state and verify BB's turn
     state = await Effect.runPromise(pokerRoom.currentState());
-    
+    const nextPlayer = currentPlayer(state);
+    if (!nextPlayer || !nextPlayer.id) {
+        throw new Error("No valid next player found");
+    }
+
     // Verify first player's bet and chips
-    const updatedFirstPlayer = state.players.find(p => p.id === firstPlayer.id);
+    const updatedFirstPlayer = state.players.find(p => p.id === current.id);
     expect(updatedFirstPlayer?.bet.round).toBe(40);
-    expect(updatedFirstPlayer?.chips).toBe(60); // 100 - 40
-    
-    // Pre-flop: Second player re-raises to 80
+    expect(updatedFirstPlayer?.chips).toBe(960); // 1000 - 40
+
+    // Player 2 (BB) re-raises to 60
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'move',
-        playerId: secondPlayer.id,
-        move: { type: 'raise', amount: 80, decisionContext: null }
+        type: "move",
+        playerId: nextPlayer.id,
+        move: { type: "raise", amount: 40, decisionContext: null }, // Raises by 40 more (total 60)
       })
     );
-    
-    // Get updated state
+
+    // Get state after BB re-raise
     state = await Effect.runPromise(pokerRoom.currentState());
-    
-    // Verify second player's bet and chips
-    const updatedSecondPlayer = state.players.find(p => p.id === secondPlayer.id);
-    expect(updatedSecondPlayer?.bet.round).toBe(80);
-    expect(updatedSecondPlayer?.chips).toBe(20); // 100 - 80
-    
-    // Verify it's first player's turn again
-    expect(state.currentPlayerIndex).toBe(firstToAct);
-    
-    // First player calls the re-raise
+    expect(state.players[1].bet.total).toBe(60);
+    expect(state.players[1].chips).toBe(940); // 980 - 40
+    expect(state.round.currentBet).toBe(60);
+    expect(state.round.phase).toBe("PRE_FLOP");
+
+    // SB calls BB's re-raise to complete pre-flop betting
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'move',
-        playerId: firstPlayer.id,
-        move: { type: 'call', decisionContext: null }
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "call", decisionContext: null },
       })
     );
-    
-    // Get updated state - we're now in the FLOP phase
+
+    // Get state after SB call - should move to FLOP
     state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.round.phase).toBe("FLOP");
+    expect(state.players[0].bet.total).toBe(60);
+    expect(state.players[0].chips).toBe(940); // 960 - 20 (call amount)
+    expect(state.pot).toBe(120); // Total pot after pre-flop
+
+    // BB acts first in FLOP
+    const bbIndex = state.players.findIndex(p => p.id === bigBlind(state).id);
+    expect(state.currentPlayerIndex).toBe(bbIndex); // BB acts first post-flop
+    console.log(1111, state);
     
-    // Verify first player's updated bet and chips - note round bet resets in FLOP phase
-    const finalFirstPlayer = state.players.find(p => p.id === firstPlayer.id);
-    expect(finalFirstPlayer?.bet.round).toBe(0);
-    expect(finalFirstPlayer?.bet.total).toBe(80);
-    expect(finalFirstPlayer?.chips).toBe(20); // 100 - 80
-    
-    // Verify pot size
-    expect(state.pot).toBe(160); // 80 + 80
-    
-    // Should transition to flop
-    expect(state.round.phase).toBe('FLOP');
+    // BB checks
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: state.players[bbIndex].id, // Use BB's ID from index
+        move: { type: "call", decisionContext: null },
+      })
+    );
+    state = await Effect.runPromise(pokerRoom.currentState());
+    console.log(2222, state);
+    expect(state.round.phase).toBe("FLOP");
+    // SB bets 20 on FLOP
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "raise", amount: 20, decisionContext: null },
+      })
+    );
+
+    // Get state after SB bet
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.players[0].bet.round).toBe(20);
+    expect(state.players[0].chips).toBe(920); // 940 - 20
+    expect(state.round.currentBet).toBe(20);
+    expect(state.round.phase).toBe("FLOP");
+
+    // BB calls SB's bet
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: state.players[bbIndex].id, // Use BB's ID from index
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
+    // Get final state - should be in TURN phase
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.round.phase).toBe("TURN");
+    expect(state.players[1].bet.total).toBe(80);
+    expect(state.players[1].chips).toBe(920); // 940 - 20
+    expect(state.pot).toBe(160); // 120 + 20 + 20
+    expect(state.community.length).toBe(4); // 3 flop cards + 1 turn card
+
+    // In FLOP, BB should act first in heads-up
+    const flopActor = currentPlayer(state);
+    expect(flopActor?.id).toBe(state.players[bbIndex].id); // BB acts first post-flop
   });
 
-  test('Complex all-in scenario - Multiple players', async () => {
+  test("Complex all-in scenario - Multiple players", async () => {
     const pokerRoom = await Effect.runPromise(makePokerRoomForTests(3));
-    
+
     // Setup: Three players join with different chip stacks
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[0],
-        playerName: PLAYER_IDS[0]
+        playerName: PLAYER_IDS[0],
       })
     );
-    
+
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[1],
-        playerName: PLAYER_IDS[1]
+        playerName: PLAYER_IDS[1],
       })
     );
-    
+
     await Effect.runPromise(
       pokerRoom.processEvent({
-        type: 'table',
-        action: 'join',
+        type: "table",
+        action: "join",
         playerId: PLAYER_IDS[2],
-        playerName: PLAYER_IDS[2]
+        playerName: PLAYER_IDS[2],
       })
     );
-    
+
     // Get initial state with starting chips
     let state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Wait for the PRE_FLOP phase to begin, then record the initial state
     let initialChips = 0;
     let initialPot = 0;
-    
+
     // Play PRE_FLOP phase - Make the third player go all-in
     let allInExecuted = false;
-    
+
     while (!allInExecuted) {
       state = await Effect.runPromise(pokerRoom.currentState());
-      
+
       // Record initial state after blinds are posted, before any betting
-      if (state.round.phase === 'PRE_FLOP' && initialChips === 0) {
+      if (state.round.phase === "PRE_FLOP" && initialChips === 0) {
         initialChips = state.players.reduce((sum, p) => sum + p.chips, 0);
         initialPot = state.pot;
         // console.log(`Initial chips: ${initialChips}, Initial pot: ${initialPot}, Total: ${initialChips + initialPot}`);
       }
-      
+
       // Check if any player can act
       if (state.currentPlayerIndex < 0) {
         break;
       }
-      
+
       const currentPlayerId = state.players[state.currentPlayerIndex].id;
-      
+
       // If current player is player3, go all-in
       if (currentPlayerId === PLAYER_IDS[2]) {
         await Effect.runPromise(
           pokerRoom.processEvent({
-            type: 'move',
+            type: "move",
             playerId: currentPlayerId,
-            move: { type: 'all_in', decisionContext: null }
+            move: { type: "all_in", decisionContext: null },
           })
         );
         allInExecuted = true;
@@ -907,52 +1158,52 @@ describe('Poker game flow tests', () => {
         // Other players call
         await Effect.runPromise(
           pokerRoom.processEvent({
-            type: 'move',
+            type: "move",
             playerId: currentPlayerId,
-            move: { type: 'call', decisionContext: null }
+            move: { type: "call", decisionContext: null },
           })
         );
       }
     }
-    
+
     // After player3 is all-in, have remaining players call or fold
     // Play through the remaining betting rounds (if any) until showdown
-    const phases = ['PRE_FLOP', 'FLOP', 'TURN', 'RIVER'];
-    
+    const phases = ["PRE_FLOP", "FLOP", "TURN", "RIVER"];
+
     for (const phase of phases) {
       let state = await Effect.runPromise(pokerRoom.currentState());
-      
+
       // Skip if we're not in this phase
       if (state.round.phase !== phase) {
         continue;
       }
-      
+
       // Have all active players check/call until the betting round is complete
       let bettingComplete = false;
       let attempts = 0;
-      
+
       while (!bettingComplete && attempts < 10) {
         attempts++;
         try {
           state = await Effect.runPromise(pokerRoom.currentState());
-          
+
           // Check if there are any players who can still act
           if (state.currentPlayerIndex < 0) {
             bettingComplete = true;
             continue;
           }
-          
+
           const currentPlayerId = state.players[state.currentPlayerIndex].id;
-          
+
           // Player calls
           await Effect.runPromise(
             pokerRoom.processEvent({
-              type: 'move',
+              type: "move",
               playerId: currentPlayerId,
-              move: { type: 'call', decisionContext: null }
+              move: { type: "call", decisionContext: null },
             })
           );
-          
+
           // Check if we've moved to the next phase
           const newState = await Effect.runPromise(pokerRoom.currentState());
           if (newState.round.phase !== phase) {
@@ -965,107 +1216,109 @@ describe('Poker game flow tests', () => {
         }
       }
     }
-    
+
     // Get state before forcing showdown
     state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Force showdown if needed
-    if (['PRE_FLOP', 'FLOP', 'TURN', 'RIVER'].includes(state.round.phase)) {
+    if (["PRE_FLOP", "FLOP", "TURN", "RIVER"].includes(state.round.phase)) {
       await Effect.runPromise(
         pokerRoom.processEvent({
-          type: 'next_round'
+          type: "next_round",
         })
       );
     }
-    
+
     // Get final state
     state = await Effect.runPromise(pokerRoom.currentState());
-    
+
     // Log final state for debugging
     const finalChips = state.players.reduce((sum, p) => sum + p.chips, 0);
     const finalPot = state.pot;
     // console.log(`Final chips: ${finalChips}, Final pot: ${finalPot}, Total: ${finalChips + finalPot}`);
     // console.log(`Round number: ${state.round.roundNumber}`);
-    
+
     // Don't strictly verify round number as it may depend on implementation
     // Just check that it has advanced from 1
     expect(state.round.roundNumber).toBeGreaterThan(1);
-    
+
     // The all-in player should either have more chips (won) or 0 chips (lost)
-    const allInPlayer = state.players.find(p => p.id === PLAYER_IDS[2]);
+    const allInPlayer = state.players.find((p) => p.id === PLAYER_IDS[2]);
     expect(allInPlayer).not.toBeUndefined();
-    
+
     // Verify total chips in system are roughly conserved
     // (allow for minor rounding differences due to integer division)
     const totalFinalChips = finalChips + finalPot;
     const totalInitialChips = initialChips + initialPot;
-    expect(Math.abs(totalFinalChips - totalInitialChips)).toBeLessThanOrEqual(1);
+    expect(Math.abs(totalFinalChips - totalInitialChips)).toBeLessThanOrEqual(
+      1
+    );
   });
 
-  test('Hand ranking verification', async () => {
+  test("Hand ranking verification", async () => {
     // Import required types and functions from poker.ts for direct testing
-    const { determineHandType } = await import('../src/poker');
-    
+    const { determineHandType } = await import("../src/poker");
+
     // Create sample card combinations for different hand types
     const highCard = [
-      { suit: 'hearts', rank: 2 },
-      { suit: 'clubs', rank: 4 },
-      { suit: 'diamonds', rank: 7 },
-      { suit: 'hearts', rank: 9 },
-      { suit: 'spades', rank: 13 }
+      { suit: "hearts", rank: 2 },
+      { suit: "clubs", rank: 4 },
+      { suit: "diamonds", rank: 7 },
+      { suit: "hearts", rank: 9 },
+      { suit: "spades", rank: 13 },
     ].sort((a, b) => a.rank - b.rank) as any;
-    
+
     const pair = [
-      { suit: 'hearts', rank: 2 },
-      { suit: 'clubs', rank: 2 },
-      { suit: 'diamonds', rank: 7 },
-      { suit: 'hearts', rank: 9 },
-      { suit: 'spades', rank: 13 }
+      { suit: "hearts", rank: 2 },
+      { suit: "clubs", rank: 2 },
+      { suit: "diamonds", rank: 7 },
+      { suit: "hearts", rank: 9 },
+      { suit: "spades", rank: 13 },
     ].sort((a, b) => a.rank - b.rank) as any;
-    
+
     const threeKind = [
-      { suit: 'hearts', rank: 7 },
-      { suit: 'clubs', rank: 7 },
-      { suit: 'diamonds', rank: 7 },
-      { suit: 'hearts', rank: 9 },
-      { suit: 'spades', rank: 13 }
+      { suit: "hearts", rank: 7 },
+      { suit: "clubs", rank: 7 },
+      { suit: "diamonds", rank: 7 },
+      { suit: "hearts", rank: 9 },
+      { suit: "spades", rank: 13 },
     ].sort((a, b) => a.rank - b.rank) as any;
-    
+
     const fourKind = [
-      { suit: 'hearts', rank: 7 },
-      { suit: 'clubs', rank: 7 },
-      { suit: 'diamonds', rank: 7 },
-      { suit: 'spades', rank: 7 },
-      { suit: 'hearts', rank: 13 }
+      { suit: "hearts", rank: 7 },
+      { suit: "clubs", rank: 7 },
+      { suit: "diamonds", rank: 7 },
+      { suit: "spades", rank: 7 },
+      { suit: "hearts", rank: 13 },
     ].sort((a, b) => a.rank - b.rank) as any;
-    
+
     const straight = [
-      { suit: 'hearts', rank: 3 },
-      { suit: 'clubs', rank: 4 },
-      { suit: 'diamonds', rank: 5 },
-      { suit: 'hearts', rank: 6 },
-      { suit: 'spades', rank: 7 }
+      { suit: "hearts", rank: 3 },
+      { suit: "clubs", rank: 4 },
+      { suit: "diamonds", rank: 5 },
+      { suit: "hearts", rank: 6 },
+      { suit: "spades", rank: 7 },
     ].sort((a, b) => a.rank - b.rank) as any;
-    
+
     const flush = [
-      { suit: 'hearts', rank: 2 },
-      { suit: 'hearts', rank: 5 },
-      { suit: 'hearts', rank: 7 },
-      { suit: 'hearts', rank: 9 },
-      { suit: 'hearts', rank: 13 }
+      { suit: "hearts", rank: 2 },
+      { suit: "hearts", rank: 5 },
+      { suit: "hearts", rank: 7 },
+      { suit: "hearts", rank: 9 },
+      { suit: "hearts", rank: 13 },
     ].sort((a, b) => a.rank - b.rank) as any;
-    
+
     const straightFlush = [
-      { suit: 'hearts', rank: 3 },
-      { suit: 'hearts', rank: 4 },
-      { suit: 'hearts', rank: 5 },
-      { suit: 'hearts', rank: 6 },
-      { suit: 'hearts', rank: 7 }
+      { suit: "hearts", rank: 3 },
+      { suit: "hearts", rank: 4 },
+      { suit: "hearts", rank: 5 },
+      { suit: "hearts", rank: 6 },
+      { suit: "hearts", rank: 7 },
     ].sort((a, b) => a.rank - b.rank) as any;
-    
+
     // Get the source code and apply workarounds for known issues
-    const source = await import('../src/poker');
-    
+    const source = await import("../src/poker");
+
     // Custom mock for testing - the implementation in the code has known issues
     const mockDetermineHandType = (cards: any) => {
       // Check for simplest patterns
@@ -1077,28 +1330,30 @@ describe('Poker game flow tests', () => {
           break;
         }
       }
-      
+
       // Group cards by rank
       const rankCounts: Record<number, number> = {};
       for (const card of cards) {
         rankCounts[card.rank] = (rankCounts[card.rank] || 0) + 1;
       }
-      
+
       const rankValues = Object.values(rankCounts);
       const hasFourOfAKind = rankValues.includes(4);
       const hasThreeOfAKind = rankValues.includes(3);
-      const pairCount = rankValues.filter(count => count === 2).length;
-      
+      const pairCount = rankValues.filter((count) => count === 2).length;
+
       // Check for straight
-      const sortedRanks = cards.map((c: any) => c.rank).sort((a: number, b: number) => a - b);
+      const sortedRanks = cards
+        .map((c: any) => c.rank)
+        .sort((a: number, b: number) => a - b);
       let isStraight = true;
       for (let i = 1; i < sortedRanks.length; i++) {
-        if (sortedRanks[i] !== sortedRanks[i-1] + 1) {
+        if (sortedRanks[i] !== sortedRanks[i - 1] + 1) {
           isStraight = false;
           break;
         }
       }
-      
+
       // Determine hand type
       if (isStraight && hasFlush) return "straight_flush";
       if (hasFourOfAKind) return "four_kind";
@@ -1110,17 +1365,673 @@ describe('Poker game flow tests', () => {
       if (pairCount === 1) return "pair";
       return "high_card";
     };
-    
-    // Test with the mock function
-    expect(mockDetermineHandType(highCard)).toBe('high_card');
-    expect(mockDetermineHandType(pair)).toBe('pair');
-    expect(mockDetermineHandType(threeKind)).toBe('three_kind');
-    expect(mockDetermineHandType(fourKind)).toBe('four_kind');
-    expect(mockDetermineHandType(straight)).toBe('straight');
-    expect(mockDetermineHandType(flush)).toBe('flush');
-    expect(mockDetermineHandType(straightFlush)).toBe('straight_flush');
-    
+
+    //     // Test with the mock function
+    expect(mockDetermineHandType(highCard)).toBe("high_card");
+    expect(mockDetermineHandType(pair)).toBe("pair");
+    expect(mockDetermineHandType(threeKind)).toBe("three_kind");
+    expect(mockDetermineHandType(fourKind)).toBe("four_kind");
+    expect(mockDetermineHandType(straight)).toBe("straight");
+    expect(mockDetermineHandType(flush)).toBe("flush");
+    expect(mockDetermineHandType(straightFlush)).toBe("straight_flush");
+
     // Note: The implementation has known issues with full_house, ace-high straights and two_pair
     // as mentioned in the FIXME comments in the determineHandType function
   });
+
+  test("Heads-up specific betting order - Dealer/SB acts first preflop, BB acts first postflop", async () => {
+    const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
+
+    // Setup: Two players join
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[0],
+        playerName: PLAYER_IDS[0],
+      })
+    );
+
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[1],
+        playerName: PLAYER_IDS[1],
+      })
+    );
+
+    // Wait until the state is ready with dealer assigned
+    let state = await Effect.runPromise(pokerRoom.currentState());
+    let attempts = 0;
+    const maxAttempts = 5;
+
+    while (!state.dealerId && attempts < maxAttempts) {
+      state = await Effect.runPromise(pokerRoom.currentState());
+      if (state.dealerId && state.round.phase === "PRE_FLOP") {
+        break;
+      }
+      attempts++;
+      await new Promise((resolve) => setTimeout(resolve, 50)); // small delay between attempts
+    }
+
+    // Check PRE-FLOP order
+    expect(state.round.phase).toBe("PRE_FLOP");
+    const preFlop = currentPlayer(state);
+    expect(preFlop).not.toBeNull();
+    expect(preFlop!.id).toBe(PLAYER_IDS[0]); // Dealer (SB) acts first in pre-flop
+
+    // Check initial betting state
+    expect(state.players[0].bet.total).toBe(10); // SB bet 10
+    expect(state.players[1].bet.total).toBe(20); // BB bet 20
+
+    // Dealer/SB acts first - calls
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
+    state = await Effect.runPromise(pokerRoom.currentState());
+
+    // Debug: Print current state
+    // console.log('State after SB action:', {
+    //   phase: state.round.phase,
+    //   currentPlayer: currentPlayer(state).id,
+    //   bets: state.players.map(p => ({
+    //     id: p.id,
+    //     bet: p.bet.total,
+    //     chips: p.chips
+    //   })),
+    //   pot: state.pot
+    // });
+
+    // Check that we're still in PRE-FLOP and it's BB's turn
+    expect(state.round.phase).toBe("PRE_FLOP"); // Should still be in PRE_FLOP
+    const afterCall = currentPlayer(state);
+    expect(afterCall).not.toBeNull();
+    expect(afterCall!.id).toBe(PLAYER_IDS[1]); // BB should be next to act
+    expect(state.community.length).toBe(0); // No community cards yet
+
+    // Check betting state after SB's call
+    expect(state.players[0].bet.total).toBe(20); // SB completed to 20
+    expect(state.players[1].bet.total).toBe(20); // BB already bet 20
+
+    // BB checks
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
+    state = await Effect.runPromise(pokerRoom.currentState());
+
+    // Debug: Print state after BB action
+    // console.log('State after BB action:', {
+    //   phase: state.round.phase,
+    //   currentPlayer: currentPlayer(state).id,
+    //   bets: state.players.map(p => ({
+    //     id: p.id,
+    //     bet: p.bet.total,
+    //     chips: p.chips
+    //   })),
+    //   pot: state.pot,
+    //   community: state.community.length
+    // });
+
+    // Now we should be in FLOP
+    expect(state.round.phase).toBe("FLOP");
+    expect(state.community.length).toBe(3);
+    const inFlop = currentPlayer(state);
+    expect(inFlop).not.toBeNull();
+    expect(inFlop!.id).toBe(PLAYER_IDS[1]); // BB acts FIRST in flop
+  });
+
+  test('Betting validations in heads-up', async () => {
+    /*
+    SB = small blind = PLAYER_IDS[0] = player 1, chips = 1000
+    BB = big blind = PLAYER_IDS[1] = player 2, chips = 1000
+    SB acts first in pre-flop
+
+    SB joins
+    BB joins
+    SB bets 10 (total 10) - chips 990 - PRE_FLOP
+    BB bets 20 (total 30) - chips 980 - PRE_FLOP
+    SB raises 30 (total 40) - chips 960 - PRE_FLOP
+    BB re-raises 40 (total 60) - chips 940 - PRE_FLOP
+    SB calls (total 60) - chips 940 - PRE_FLOP
+    SB raises 20 (total 80) - chips 920 - FLOP
+    BB calls (total 80) - chips 920 - FLOP
+    PHASE TURN after BB calls
+    */
+    const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
+    
+    // Setup: Two players join
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: 'table',
+        action: 'join',
+        playerId: PLAYER_IDS[0],
+        playerName: PLAYER_IDS[0]
+      })
+    );
+    
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: 'table',
+        action: 'join',
+        playerId: PLAYER_IDS[1],
+        playerName: PLAYER_IDS[1]
+      })
+    );
+    
+    // Get initial state and wait for PRE_FLOP phase
+    let state = await Effect.runPromise(pokerRoom.currentState());
+    let attempts = 0;
+    const maxAttempts = 10;
+
+    // Wait until we're in PRE_FLOP and have a valid current player
+    while (attempts < maxAttempts) {
+        state = await Effect.runPromise(pokerRoom.currentState());
+        const current = currentPlayer(state);
+        
+        if (state.round.phase === "PRE_FLOP" && current && current.id) {
+            break;
+        }
+        
+        attempts++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Ensure we're in the correct phase and state
+    expect(state.round.phase).toBe("PRE_FLOP");
+    expect(state.tableStatus).toBe("PLAYING");
+    
+    // Verify initial blinds state
+    expect(state.players[0].bet.total).toBe(10); // SB bet 10
+    expect(state.players[0].chips).toBe(990); // 1000 - 10
+    expect(state.players[1].bet.total).toBe(20); // BB bet 20
+    expect(state.players[1].chips).toBe(980); // 1000 - 20
+
+    // SB raises to 40
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "raise", amount: 30, decisionContext: null }, // Raises by 30 more (total 40)
+      })
+    );
+
+    // Get state after SB raise
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.players[0].bet.total).toBe(40);
+    expect(state.players[0].chips).toBe(960); // 990 - 30
+    expect(state.round.currentBet).toBe(40);
+    expect(state.round.phase).toBe("PRE_FLOP");
+
+    // BB re-raises to 60
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "raise", amount: 40, decisionContext: null }, // Raises by 40 more (total 60)
+      })
+    );
+
+    // Get state after BB re-raise
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.players[1].bet.total).toBe(60);
+    expect(state.players[1].chips).toBe(940); // 980 - 40
+    expect(state.round.currentBet).toBe(60);
+    expect(state.round.phase).toBe("PRE_FLOP");
+
+    // SB calls BB's re-raise to complete pre-flop betting
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
+    // Get state after SB call - should move to FLOP
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.round.phase).toBe("FLOP");
+    expect(state.players[0].bet.total).toBe(60);
+    expect(state.players[0].chips).toBe(940); // 960 - 20 (call amount)
+    expect(state.pot).toBe(120); // Total pot after pre-flop
+
+    // BB acts first in FLOP
+    const bbIndex = state.players.findIndex(p => p.id === bigBlind(state).id);
+    expect(state.currentPlayerIndex).toBe(bbIndex); // BB acts first post-flop
+    console.log(1111, state);
+    
+    // BB checks
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: state.players[bbIndex].id, // Use BB's ID from index
+        move: { type: "call", decisionContext: null },
+      })
+    );
+    state = await Effect.runPromise(pokerRoom.currentState());
+    console.log(2222, state);
+    expect(state.round.phase).toBe("FLOP");
+    // SB bets 20 on FLOP
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "raise", amount: 20, decisionContext: null },
+      })
+    );
+
+    // Get state after SB bet
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.players[0].bet.round).toBe(20);
+    expect(state.players[0].chips).toBe(920); // 940 - 20
+    expect(state.round.currentBet).toBe(20);
+    expect(state.round.phase).toBe("FLOP");
+
+    // BB calls SB's bet
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: state.players[bbIndex].id, // Use BB's ID from index
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
+    // Get final state - should be in TURN phase
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.round.phase).toBe("TURN");
+    expect(state.players[1].bet.total).toBe(80);
+    expect(state.players[1].chips).toBe(920); // 940 - 20
+    expect(state.pot).toBe(160); // 120 + 20 + 20
+    expect(state.community.length).toBe(4); // 3 flop cards + 1 turn card
+
+    // In FLOP, BB should act first in heads-up
+    const flopActor = currentPlayer(state);
+    expect(flopActor?.id).toBe(state.players[bbIndex].id); // BB acts first post-flop
+  });
+
+  test("Game Over - Player loses all chips", async () => {
+    const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
+
+    // Setup: Two players join
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[0],
+        playerName: PLAYER_IDS[0],
+      })
+    );
+
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[1],
+        playerName: PLAYER_IDS[1],
+      })
+    );
+
+    // Get initial state and wait for PRE_FLOP phase
+    let state = await Effect.runPromise(pokerRoom.currentState());
+    let attempts = 0;
+    const maxAttempts = 10;
+
+    // Wait until we're in PRE_FLOP and have a valid current player
+    while (attempts < maxAttempts) {
+        state = await Effect.runPromise(pokerRoom.currentState());
+        const current = currentPlayer(state);
+        
+        if (state.round.phase === "PRE_FLOP" && current && current.id) {
+            break;
+        }
+        
+        attempts++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Ensure we're in the correct phase and state
+    expect(state.round.phase).toBe("PRE_FLOP");
+    expect(state.tableStatus).toBe("PLAYING");
+    
+    // Get current player and ensure it's valid
+    const current = currentPlayer(state);
+    if (!current || !current.id) {
+        throw new Error("No valid current player found after waiting");
+    }
+
+    // Player 1 (SB/Dealer) goes all-in
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: current.id,
+        move: { type: "raise", amount: 1000, decisionContext: null },
+      })
+    );
+
+    // Get next state and verify BB's turn
+    state = await Effect.runPromise(pokerRoom.currentState());
+    const nextPlayer = currentPlayer(state);
+    if (!nextPlayer || !nextPlayer.id) {
+        throw new Error("No valid next player found");
+    }
+
+    // Player 2 (BB) calls the all-in
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: nextPlayer.id,
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
+    // Wait for showdown
+    attempts = 0;
+    while (attempts < maxAttempts) {
+        state = await Effect.runPromise(pokerRoom.currentState());
+        if (state.round.phase === "SHOWDOWN") break;
+        attempts++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Verify final state
+    expect(state.round.phase).toBe("SHOWDOWN");
+    expect(state.tableStatus).toBe("ROUND_OVER");
+
+    // One player should have 0 chips and the other all chips
+    const loser = state.players.find((p) => p.chips === 0);
+    const winner = state.players.find((p) => p.chips === 2000); // All chips in play
+
+    expect(loser).not.toBeUndefined();
+    expect(winner).not.toBeUndefined();
+    expect(state.winner).toBe(winner?.id ?? null);
+    expect(state.tableStatus).toBe("ROUND_OVER");
+  });
+
+  test('All-in scenarios in heads-up', async () => {
+    const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
+
+    // Setup: Two players join
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[0],
+        playerName: PLAYER_IDS[0],
+      })
+    );
+
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "table",
+        action: "join",
+        playerId: PLAYER_IDS[1],
+        playerName: PLAYER_IDS[1],
+      })
+    );
+
+    // Get initial state and wait for PRE_FLOP phase
+    let state = await Effect.runPromise(pokerRoom.currentState());
+    let attempts = 0;
+    const maxAttempts = 10;
+
+    // Wait until we're in PRE_FLOP and have a valid current player
+    while (attempts < maxAttempts) {
+        state = await Effect.runPromise(pokerRoom.currentState());
+        const current = currentPlayer(state);
+        
+        if (state.round.phase === "PRE_FLOP" && current && current.id) {
+            break;
+        }
+        
+        attempts++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Ensure we're in the correct phase and state
+    expect(state.round.phase).toBe("PRE_FLOP");
+    expect(state.tableStatus).toBe("PLAYING");
+    
+    // Get current player and ensure it's valid
+    const current = currentPlayer(state);
+    if (!current || !current.id) {
+        throw new Error("No valid current player found after waiting");
+    }
+
+    // Player 1 (SB/Dealer) raises to 40 (2x BB)
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: current.id,
+        move: { type: "raise", amount: 40, decisionContext: null },
+      })
+    );
+
+    // Get next state and verify BB's turn
+    state = await Effect.runPromise(pokerRoom.currentState());
+    const nextPlayer = currentPlayer(state);
+    if (!nextPlayer || !nextPlayer.id) {
+        throw new Error("No valid next player found");
+    }
+
+    // Player 2 (BB) goes all-in
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: nextPlayer.id,
+        move: { type: "all_in", decisionContext: null },
+      })
+    );
+
+    // Get state and verify SB's turn
+    state = await Effect.runPromise(pokerRoom.currentState());
+    const lastPlayer = currentPlayer(state);
+    if (!lastPlayer || !lastPlayer.id) {
+        throw new Error("No valid last player found");
+    }
+
+    // Player 1 calls the all-in
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: lastPlayer.id,
+        move: { type: "call", decisionContext: null },
+      })
+    );
+
+    // Wait for showdown
+    attempts = 0;
+    while (attempts < maxAttempts) {
+        state = await Effect.runPromise(pokerRoom.currentState());
+        if (state.round.phase === "SHOWDOWN") break;
+        attempts++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Verify final state
+    expect(state.round.phase).toBe("SHOWDOWN");
+    expect(state.tableStatus).toBe("ROUND_OVER");
+
+    // One player should have 0 chips and the other all chips
+    const loser = state.players.find((p) => p.chips === 0);
+    const winner = state.players.find((p) => p.chips === 2000); // All chips in play
+
+    expect(loser).not.toBeUndefined();
+    expect(winner).not.toBeUndefined();
+    expect(state.winner).toBe(winner?.id ?? null);
+    expect(state.tableStatus).toBe("ROUND_OVER");
+  });
+
+
+  test('Betting validations in heads-up PHASES', async () => {
+    const pokerRoom = await Effect.runPromise(makePokerRoomForTests(2));
+    
+    // Setup: Two players join
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: 'table',
+        action: 'join',
+        playerId: PLAYER_IDS[0],
+        playerName: PLAYER_IDS[0]
+      })
+    );
+    
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: 'table',
+        action: 'join',
+        playerId: PLAYER_IDS[1],
+        playerName: PLAYER_IDS[1]
+      })
+    );
+    
+    // Get initial state and wait for PRE_FLOP phase
+    let state = await Effect.runPromise(pokerRoom.currentState());
+    let attempts = 0;
+    const maxAttempts = 10;
+
+    // Wait until we're in PRE_FLOP and have a valid current player
+    while (attempts < maxAttempts) {
+        state = await Effect.runPromise(pokerRoom.currentState());
+        const current = currentPlayer(state);
+        
+        if (state.round.phase === "PRE_FLOP" && current && current.id) {
+            break;
+        }
+        
+        attempts++;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Ensure we're in the correct phase and state
+    expect(state.round.phase).toBe("PRE_FLOP");
+    expect(state.tableStatus).toBe("PLAYING");
+    
+    // Get current player and ensure it's valid
+    const current = currentPlayer(state);
+    expect(current).not.toBeNull();
+    expect(current!.id).toBe(PLAYER_IDS[0]); // SB acts first in pre-flop
+
+    // Test 1: Out of turn betting (BB trying to act during SB's turn)
+    let outOfTurnError = null;
+    try {
+      await Effect.runPromise(
+        pokerRoom.processEvent({
+          type: "move",
+          playerId: PLAYER_IDS[1],
+          move: { type: "raise", amount: 40, decisionContext: null }
+        })
+      );
+    } catch (error) {
+      outOfTurnError = error;
+    }
+    expect(outOfTurnError).not.toBeNull();
+
+    // Test 2: SB raises to 40 (valid raise)
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "raise", amount: 30, decisionContext: null } // 10 (current) + 30 = 40 total
+      })
+    );
+
+    // Get state after raise
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.round.currentBet).toBe(40);
+    expect(state.players[0].bet.round).toBe(40);
+    expect(state.players[0].chips).toBe(960); // 1000 - 40
+
+    // Test 3: BB re-raises to 60
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "raise", amount: 40, decisionContext: null } // 20 (current) + 40 amount = 60 total
+      })
+    );
+
+    // Get state after BB re-raise
+    state = await Effect.runPromise(pokerRoom.currentState());
+    console.log('state after bb re-raise', state);
+    expect(state.round.currentBet).toBe(60);
+    expect(state.players[1].bet.round).toBe(60);
+    expect(state.players[1].chips).toBe(940); // 980 - 60
+    expect(state.round.phase).toBe("PRE_FLOP");
+
+    // Test 4: SB calls
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "call", decisionContext: null }
+      })
+    );
+
+    // Get state after call
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.round.phase).toBe("FLOP");
+    expect(state.community.length).toBe(3);
+    expect(state.pot).toBe(120); // Both players bet 60
+
+    // Test 5: BB acts first post-flop
+    expect(currentPlayer(state)!.id).toBe(PLAYER_IDS[1]); // BB acts first post-flop
+    console.log(
+      "player current",
+      state.players[state.currentPlayerIndex].id,
+      state.players.find((p) => p.id === PLAYER_IDS[1])?.id,
+      PLAYER_IDS[1]
+    );
+    // BB checks
+    state = await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "call", decisionContext: null }
+      })
+    );
+    state = await Effect.runPromise(pokerRoom.currentState());
+    console.log('post call', state);
+    expect(state.round.phase).toBe("FLOP");
+    // Test 6: SB bets after BB checks
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[0],
+        move: { type: "raise", amount: 20, decisionContext: null } // Total target amount of 20
+      })
+    );
+
+    // Get state after SB bet
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.round.phase).toBe("FLOP");
+    expect(state.round.currentBet).toBe(20);
+    expect(state.players[0].bet.round).toBe(20);
+
+    // Test 7: BB can raise after checking
+    await Effect.runPromise(
+      pokerRoom.processEvent({
+        type: "move",
+        playerId: PLAYER_IDS[1],
+        move: { type: "raise", amount: 40, decisionContext: null } // Total target amount of 40
+      })
+    );
+
+    // Get final state
+    state = await Effect.runPromise(pokerRoom.currentState());
+    expect(state.round.phase).toBe("FLOP");
+    expect(state.round.currentBet).toBe(40);
+    expect(state.players[1].bet.round).toBe(40);
+    expect(state.players[1].chips).toBeLessThan(state.players[0].chips); // BB should have less chips after raising
+  });
+
 }); 


### PR DESCRIPTION
# Poker Implement All-in and Improve Game Logic

## Overview
This PR implements the all-in functionality and improves several core aspects of the poker game logic, including hand comparison, betting order in heads-up games, and pot distribution.

## Key Changes
- Implement complete all-in functionality with proper pot distribution
- Fix betting order in heads-up poker (SB first pre-flop, BB first post-flop)
- Improve hand comparison logic with support for Ace-high straights
- Add comprehensive test coverage for all new features
- Update poker client to handle all-in scenarios
- Increase initial chips to 1000 for better gameplay

## Technical Details

### All-in Implementation
- Added support for multiple side pots when players go all-in
- Implemented correct pot distribution based on player contributions
- Added protection against invalid states during all-in scenarios

### Heads-up Poker Improvements
- Fixed betting order to follow poker rules:
  - Small Blind acts first in pre-flop
  - Big Blind acts first in post-flop rounds
- Added proper tracking of player actions with `playedThisPhase` field

### Hand Comparison Enhancements
- Improved hand type determination logic
- Added proper support for Ace-high straights
- Implemented comprehensive hand comparison for all poker hand types
- Added tie-breaking logic for identical hand types

## Testing
Added extensive test coverage including:
- All-in scenarios with multiple players
- Complete game flow for heads-up poker
- Pot distribution in various scenarios
- Hand comparison edge cases
- Betting order validation

## Breaking Changes
None. All changes are backward compatible.

## Dependencies
No new dependencies added.

## Related Issues
Closes #113