### PR TITLE
feat 135 start endpoint

### DIFF
--- a/agent/packages/client-poker/src/schemas.ts
+++ b/agent/packages/client-poker/src/schemas.ts
@@ -189,7 +189,8 @@ export const SystemEventSchema = Schema.Union(
   Schema.Struct({ type: Schema.Literal("start") }),
   Schema.Struct({ type: Schema.Literal("transition_phase") }),
   Schema.Struct({ type: Schema.Literal("next_round") }),
-  Schema.Struct({ type: Schema.Literal("end_game") })
+  Schema.Struct({ type: Schema.Literal("end_game") }),
+  Schema.Struct({ type: Schema.Literal("auto_restart") })
 );
 export type SystemEvent = typeof SystemEventSchema.Type;
 

--- a/front/src/types/schemas.ts
+++ b/front/src/types/schemas.ts
@@ -211,7 +211,10 @@ export type StateMachineError = typeof StateMachineErrorSchema.Type;
 export const ProcessEventErrorSchema = Schema.Union(
   StateMachineErrorSchema,
   Schema.Struct({ type: Schema.Literal("not_your_turn") }),
-  Schema.Struct({ type: Schema.Literal("table_locked") })
+  Schema.Struct({ type: Schema.Literal("table_locked") }),
+  Schema.Struct({ type: Schema.Literal("game_already_started") }),
+  Schema.Struct({ type: Schema.Literal("insufficient_players") }),
+  Schema.Struct({ type: Schema.Literal("game_not_over") })
 );
 export type ProcessEventError = typeof ProcessEventErrorSchema.Type;
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "packages/*"
   ],
   "scripts": {
-    "poker-server-dev": "bun run --watch packages/server/src/index.ts",
+    "poker-server-dev": "bun run --watch packages/server-poker/src/index.ts",
     "poker-test": "bun test packages/poker-state-machine/test",
     "server-dev": "bun run --cwd server-main dev",
     "front-poker-schema": "cp packages/poker-state-machine/src/schemas.ts front/src/types/schemas.ts",
     "front-dev": "bun run front-poker-schema && bun run --cwd front dev -p 4000",
-    "front-build": "bun run --cwd front build",
+    "front-build": "bun run front-poker-schema && bun run --cwd front build",
     "agent-build": "cp packages/poker-state-machine/src/schemas.ts agent/packages/client-poker/src/schemas.ts && pnpm --dir agent build",
     "agent-dev": "pnpm agent-build && pnpm --dir agent start:debug",
     "agent": "pnpm agent-build && pnpm --dir agent start"

--- a/packages/poker-state-machine/src/schemas.ts
+++ b/packages/poker-state-machine/src/schemas.ts
@@ -211,7 +211,10 @@ export type StateMachineError = typeof StateMachineErrorSchema.Type;
 export const ProcessEventErrorSchema = Schema.Union(
   StateMachineErrorSchema,
   Schema.Struct({ type: Schema.Literal("not_your_turn") }),
-  Schema.Struct({ type: Schema.Literal("table_locked") })
+  Schema.Struct({ type: Schema.Literal("table_locked") }),
+  Schema.Struct({ type: Schema.Literal("game_already_started") }),
+  Schema.Struct({ type: Schema.Literal("insufficient_players") }),
+  Schema.Struct({ type: Schema.Literal("game_not_over") })
 );
 export type ProcessEventError = typeof ProcessEventErrorSchema.Type;
 

--- a/packages/poker-state-machine/test/full_game_flow.test.ts
+++ b/packages/poker-state-machine/test/full_game_flow.test.ts
@@ -10,6 +10,9 @@ describe("Poker game flow tests", () => {
   // Unique player IDs to avoid duplication issues in the original test
   const PLAYER_IDS = ["player1", "player2", "player3"];
 
+  // set the environment variable to true
+  process.env.AUTO_RESTART_ENABLED = "true";
+
   // Helper function to create a test player
   function createPlayer(
     id: string,

--- a/packages/server-poker/src/router.ts
+++ b/packages/server-poker/src/router.ts
@@ -28,6 +28,10 @@ export class PokerRpc extends RpcGroup.make(
     success: PokerStateSchema,
     error: ProcessingStateStreamErrorsSchema,
     stream: true,
+  }),
+  Rpc.make("startGame", {
+    success: PokerStateSchema,
+    error: ProcessingStateStreamErrorsSchema,
   })
 ) {}
 
@@ -48,6 +52,9 @@ export const PokerRpcLive = PokerRpc.toLayer(
       },
       stateUpdates: (_payload, _headers) => {
         return ROOM.stateUpdates
+      },
+      startGame: (_payload, _headers) => {
+        return ROOM.startGame();
       },
     };
   })


### PR DESCRIPTION
- Modified package.json scripts for server and front build processes.
- Added an expanded ProcessEventErrorSchema with new error types.
- Implemented startGame method in PokerGameService and integrated it into the PokerRpc class.
- Adjusted tests to enable auto-restart for comprehensive coverage.

Closes #135 