### PR TITLE
chore: add temp directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ dist
 
 # Finder (MacOS) folder config
 .DS_Store
+
+temp/


### PR DESCRIPTION
Add temp/ directory to gitignore to prevent temporary files and folders from being tracked in version control.