### PR TITLE
fix: add trust proxy configuration for express-rate-limit

### DIFF
--- a/server-main/src/index.ts
+++ b/server-main/src/index.ts
@@ -19,6 +19,9 @@ dotenv.config();
 
 const app = express();
 
+// Trust proxy for rate limiting to work correctly behind a proxy
+app.set('trust proxy', 1);
+
 // Middleware
 app.use(express.json());
 


### PR DESCRIPTION
- Add app.set('trust proxy', 1) to handle X-Forwarded-For headers
- Fixes ERR_ERL_UNEXPECTED_X_FORWARDED_FOR error in production
- Allows rate limiter to correctly identify client IPs behind proxy